### PR TITLE
chore: remove unnecessary timeout in otel

### DIFF
--- a/pingap-otel/src/lib.rs
+++ b/pingap-otel/src/lib.rs
@@ -234,7 +234,6 @@ impl BackgroundService for TracerService {
         let result = opentelemetry_otlp::SpanExporter::builder()
             .with_tonic()
             .with_endpoint(&self.endpoint)
-            .with_timeout(Duration::from_secs(3))
             .with_timeout(self.config.timeout)
             .build()
             .map(|exporter| {


### PR DESCRIPTION
## Remove unnecessary timeout in `pingap-otel`

just removed unnecessary timeout settings from `openentelemetry_otlp::SpanExporter` because of duplicated timeout settings.